### PR TITLE
🔨 created context language

### DIFF
--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useState } from "react";
+
+export const LanguageContext = createContext(null);
+
+interface languageContextI {
+  children: React.ReactNode;
+}
+
+interface contextDataI {
+  language: string;
+  setLanguage: (language: string) => void;
+}
+
+export const LanguageContextProvider = ({ children }: languageContextI) => {
+  const [language, setLanguage] = useState("en");
+
+  const data: contextDataI = {
+    language,
+    setLanguage,
+  };
+
+  return (
+    <LanguageContext.Provider value={data}>{children}</LanguageContext.Provider>
+  );
+};


### PR DESCRIPTION
created a language context, the component has a missing initialContext value that needs to be passed down to the createContext() function. 